### PR TITLE
Here's the revised message:

### DIFF
--- a/docs/.keep
+++ b/docs/.keep
@@ -1,0 +1,1 @@
+# This is a placeholder file to ensure the docs directory is tracked by Git.

--- a/docs/atom_f90.md
+++ b/docs/atom_f90.md
@@ -1,0 +1,77 @@
+# Documentation for `src/atom.f90`
+
+## Overview
+
+The `Class_atom` module defines a derived data type `atom` which represents a single atom within a crystal unit cell. It stores information about the atom's position, its magnetic moment (orientation), its site type (e.g., for bipartite lattices like honeycomb), and details about its neighboring atoms, including their indices and the vectors connecting to them. This module is fundamental for constructing the unit cell and subsequently the Hamiltonian of the system.
+
+## Key Components
+
+### `module Class_atom`
+
+This is the main module.
+
+### `enum, bind(c)` for Site Types
+
+Defines enumerators for classifying atom sites, particularly useful for lattices with sublattices:
+-   `A_site`: Represents an atom on the A sublattice.
+-   `B_site`: Represents an atom on the B sublattice.
+-   `no_site`: Used when sublattice distinction is not applicable or needed.
+
+### `type atom`
+
+A derived data type to store properties of an individual atom.
+
+**Key Members (Parameters):**
+
+-   `m_phi (real(8))`: Azimuthal angle $\phi$ of the atom's magnetic moment in spherical coordinates.
+-   `m_theta (real(8))`: Polar angle $\theta$ of the atom's magnetic moment in spherical coordinates. The convention usually follows physics standards (theta is angle from z-axis, phi is angle from x-axis in xy-plane).
+-   `pos (real(8), dimension(3))`: Cartesian coordinates $(x, y, z)$ of the atom's position in real space, typically in atomic units or units defined by a lattice constant.
+-   `site_type (integer(4))`: An integer representing the site type, using values from the `enum` (A_site, B_site, no_site).
+-   `neigh_idx (integer, allocatable :: neigh_idx(:))`: An array storing the indices (within the unit cell's atom list) of its neighboring atoms.
+-   `neigh_conn (real(8), allocatable :: neigh_conn(:,:))`: A 2D array where each row is a 3D vector representing the real-space connection vector from this atom to a corresponding neighbor in `neigh_idx`.
+-   `conn_type (integer(4), allocatable :: conn_type(:))`: An array storing the type of connection for each neighbor (e.g., nearest neighbor, second nearest neighbor, from an `enum` likely defined in `Class_unit_cell`).
+-   `me (integer)`: MPI rank of the current process.
+-   `nProcs (integer)`: Total number of MPI processes.
+
+**Key Procedures (Methods):**
+
+-   **`init_ferro_z(p_pos, site) result(self)`**: Constructor function. Initializes an `atom` object.
+    -   **Arguments:**
+        -   `p_pos (real(8), intent(in))`: The 3D position of the atom.
+        -   `site (integer, optional)`: The site type of the atom. Defaults to `no_site` if not provided.
+    -   Sets the initial magnetic moment to point along the positive z-axis (phi=0, theta=0).
+    -   Assigns the given position and site type.
+    -   Initializes MPI rank and process count.
+-   **`get_m_cart(self) result(coord)`**: Function that returns the Cartesian coordinates $(m_x, m_y, m_z)$ of the atom's magnetic moment, calculated from its spherical angles `m_phi` and `m_theta`. Assumes a unit magnetic moment.
+-   **`set_sphere(self, phi, theta)`**: Subroutine to set the atom's magnetic moment using spherical coordinates.
+    -   **Arguments:**
+        -   `phi (real(8), intent(in))`: The new azimuthal angle.
+        -   `theta (real(8), intent(in))`: The new polar angle.
+-   **`set_m_cart(self, x, y, z)`**: Subroutine to set the atom's magnetic moment using Cartesian coordinates.
+    -   **Arguments:**
+        -   `x, y, z (real(8), intent(in))`: The Cartesian components of the new magnetic moment.
+    -   Converts these Cartesian coordinates to spherical angles (`m_phi`, `m_theta`) and stores them.
+    -   Includes a check to ensure the input vector is approximately normalized.
+-   **`free_atm(self)`**: Subroutine to deallocate allocatable members of the `atom` object (`neigh_idx`, `neigh_conn`). Note: `conn_type` is missing from deallocation in the provided code, which could be a potential memory leak if it's allocated.
+-   **`compare_to_root(self) result(success)`**: Function used for testing in an MPI environment. It compares all members of the `atom` object on the current process with the corresponding values from the root process (rank 0) and returns `.True.` if they all match within tolerance, `.False.` otherwise. This helps ensure data consistency across MPI processes.
+
+## Important Variables/Constants (within `type atom`)
+
+-   **`m_phi, m_theta (real(8))`**: These two angles define the orientation of the atom's magnetic moment, which is crucial for magnetic Hamiltonians.
+-   **`pos(3) (real(8))`**: The atom's position, essential for calculating distances and phase factors in hopping terms.
+-   **`site_type (integer(4))`**: Distinguishes atoms on different sublattices, which can have different onsite energies or behave differently under certain interactions.
+-   **`neigh_idx(:)`**: Array of indices pointing to neighboring atoms. This, along with `neigh_conn` and `conn_type`, defines the local environment and connectivity of the atom, which is necessary for constructing hopping terms in the Hamiltonian.
+
+## Dependencies/Interactions
+
+-   **`Class_helper`**:
+    -   `my_norm2`: Used in `set_m_cart` to check normalization of the input magnetic vector and in `compare_to_root` to compare position vectors.
+    -   `mtx_norm`: Used in `compare_to_root` to compare neighbor connection matrices.
+    -   `error_msg`: Used for reporting errors, for example, if the spin vector in `set_m_cart` is not normalized, or if inconsistencies are found in `compare_to_root`.
+-   **`Constants`**: While not explicitly shown using a constant from this module in the provided snippet, it's listed as a dependency. It likely provides physical constants or mathematical constants (like PI if not intrinsic) that might be used in more extensive calculations involving atoms. The site type enum itself could also be considered part of a constants collection.
+-   **`mpi`**: Standard MPI module used for:
+    -   Getting MPI communicator size (`MPI_Comm_size`) and rank (`MPI_Comm_rank`) in `init_ferro_z`.
+    -   Broadcasting data (`MPI_Bcast`) and performing comparisons in `compare_to_root`.
+    -   Error checking for MPI calls (`check_ierr`, which is likely a wrapper from `Class_helper` or `mypi`).
+
+The `atom` type is a building block for the `unit_cell` type in `Class_unit_cell.f90`. The `unit_cell` module will typically create an array of `atom` objects and then populate their neighbor information based on the lattice geometry.

--- a/docs/hamiltonian_f90.md
+++ b/docs/hamiltonian_f90.md
@@ -1,0 +1,116 @@
+# Documentation for `src/hamiltionian.f90`
+
+## Overview
+
+The `Class_hamiltionian` module defines the electronic Hamiltonian for a crystal structure. It encapsulates the parameters and methods required to construct the Hamiltonian matrix for given k-points, calculate its eigenvalues and eigenvectors, and compute derivatives of the Hamiltonian with respect to k (which are essential for velocity operators and Berry curvature calculations). The module supports various types of Hamiltonians, including s-orbital and p-orbital models, nearest and second-nearest neighbor hopping, spin-orbit coupling (Rashba and intrinsic), local exchange splitting, and specialized models like the Haldane model and Kane-Mele model. It also handles MPI for parallel execution and reading configurations.
+
+## Key Components
+
+### `module Class_hamiltonian`
+
+This is the main module.
+
+### `type hamil`
+
+A derived data type that holds all the parameters and procedures related to the Hamiltonian.
+
+**Key Members (Parameters):**
+
+-   `E_fermi (real(8), allocatable :: E_fermi(:))`: Array of Fermi levels.
+-   `temp (real(8))`: Temperature used in the Fermi-Dirac distribution.
+-   `E_s (real(8))`: Onsite energy for s-orbitals.
+-   `E_A, E_B (real(8))`: Onsite energies for A and B sublattice sites (e.g., in honeycomb).
+-   `E_p(3) (real(8))`: Onsite energies for p_x, p_y, p_z orbitals.
+-   `Vss_sig (real(8))`: Nearest neighbor hopping for s-orbitals (sigma bond).
+-   `Vpp_pi, Vpp_sig (real(8))`: Nearest neighbor hopping for p-orbitals (pi and sigma bonds).
+-   `V2pp_pi, V2pp_sig (real(8))`: Second nearest neighbor hopping for p-orbitals.
+-   `eta_soc (real(8))`: Parameter for p-state intrinsic spin-orbit coupling.
+-   `t_2 (real(8))`: Amplitude for 2nd nearest neighbor hopping (Haldane model).
+-   `phi_2 (real(8))`: Phase for 2nd nearest neighbor hopping (Haldane model).
+-   `t_so (real(8))`: Rashba spin-orbit coupling strength.
+-   `lambda (real(8))`: Local exchange splitting strength.
+-   `HB1, HB2, HB_eta (real(8))`: Parameters for "Hongbin's model".
+-   `lambda_KM (real(8))`: Parameter for the Kane-Mele term.
+-   `gamma (real(8))`: Broadening factor (e.g., for Green's functions, conductivity).
+-   `drop_Vx_layers(:), drop_Vy_layers(:) (real(8), allocatable)`: Specifies layers where hopping derivatives (velocities) in x or y are zeroed out.
+-   `del_H (complex(8), allocatable :: del_H(:,:))`: Matrix for the derivative of H w.r.t. k.
+-   `prefix (character(len=300))`: Output file prefix.
+-   `nProcs (integer)`: Number of MPI processes.
+-   `me (integer)`: MPI rank of the current process.
+-   `num_orb (integer)`: Number of orbitals per atom (e.g., 1 for s, 3 for p).
+-   `num_up (integer)`: Number of spin-up states (num_orb * num_atoms_in_UC).
+-   `test_run (logical)`: Flag to perform unit tests.
+-   `UC (type(unit_cell))`: Unit cell object.
+-   `units (type(units))`: Units object for physical quantities.
+
+**Key Procedures (Methods):**
+
+-   **`init_hamil(cfg) result(self)`**: Constructor. Initializes the `hamil` object from a configuration (`cfg`). Reads parameters, broadcasts them using MPI.
+-   **`Bcast_hamil(self)`**: Broadcasts Hamiltonian parameters to all MPI ranks.
+-   **`setup_H(self, k, H)`**: Constructs the Hamiltonian matrix `H` for a given k-point `k`. This is a central routine that calls various `set_*` subroutines based on the enabled parameters.
+-   **`calc_eigenvalues(self, k_list, eig_val)`**: Calculates eigenvalues `eig_val` for a list of k-points `k_list`. Uses LAPACK's `zheevd`.
+-   **`calc_single_eigenvalue(self, k, eig_val)`**: Calculates eigenvalues for a single k-point.
+-   **`calc_eig_and_velo(self, k, eig_val, del_kx, del_ky, pert_log)`**: Calculates eigenvalues and velocity matrices (derivatives of H) `del_kx`, `del_ky`. Can include perturbative corrections (`pert_log`).
+-   **`set_fermi(self, cfg)`**: Sets the Fermi energy levels based on the configuration.
+-   **`fermi_distr(self, E, n_ferm) result(ferm)`**: Calculates the Fermi-Dirac distribution value.
+-   **`set_EigenE(self, H)`**: Adds onsite eigenenergies (E_s, E_A, E_B) to the Hamiltonian `H`.
+-   **`set_p_energy(self, H)`**: Adds onsite p-orbital energies (E_p) to `H`.
+-   **`set_hopping(self, k, H)`**: Adds nearest-neighbor hopping terms to `H`. Calls `set_hopp_mtx`.
+-   **`set_snd_hopping(self, k, H)`**: Adds second-nearest-neighbor hopping terms to `H`. Calls `set_snd_hopp_mtx`.
+-   **`set_haldane_hopping(self, k, H)`**: Adds Haldane model specific second-neighbor hopping terms.
+-   **`set_rashba_SO(self, k, H)`**: Adds Rashba spin-orbit coupling terms.
+-   **`set_SOC(self, H)`**: Adds intrinsic p-orbital spin-orbit coupling. Calls `set_small_SOC`.
+-   **`set_loc_exch(self, H)`**: Adds local exchange splitting (Stoner magnetism). Calls `setup_Stoner_mtx`.
+-   **`set_KaneMele_exch(self, k, H)`**: Adds Kane-Mele model terms.
+-   **`set_hongbin_hopp(self, k, H)`**: Adds hopping terms for "Hongbin's model".
+-   **`set_hongbin_SOC(self, H)`**: Adds SOC terms for "Hongbin's model".
+-   **`set_hopp_mtx(self, R, hopp_mtx)`**: Sets up the orbital-space hopping matrix for a given connection vector `R` (for s or p orbitals).
+-   **`set_snd_hopp_mtx(self, R, hopp_mtx)`**: Similar to `set_hopp_mtx` but for second-nearest neighbors (p-orbitals).
+-   **`set_p_hopp_mtx(R, Vpp_sig, Vpp_pi, hopp_mtx)`**: Helper for p-orbital hopping matrix construction based on Slater-Koster parameters.
+-   **`set_derivative_k(self, k, k_idx)`**: Calculates `self%del_H`, the derivative of the Hamiltonian with respect to `k(k_idx)`. Calls various `set_derivative_*` subroutines.
+-   **`set_deriv_FD(self, k, k_idx, del_H)`**: Calculates `del_H` using finite differences (for testing or for terms without analytical derivatives).
+-   **`set_derivative_hopping(self, k, k_idx)`**: Analytical derivative for nearest-neighbor hopping.
+-   **`set_derivative_snd_hopping(self, k, k_idx)`**: Analytical derivative for second-nearest-neighbor hopping.
+-   **`set_derivative_haldane_hopping(self, k, k_idx)`**: Analytical derivative for Haldane hopping.
+-   **`set_derivative_rashba_so(self, k, k_idx)`**: Analytical derivative for Rashba SOC.
+-   **`set_derivative_KM(self, k)`**: Analytical derivative for Kane-Mele term.
+-   **`compare_derivative(self, k)`**: Compares analytical derivatives with finite difference calculations for testing.
+-   **`calc_velo_mtx(self, k, derive_idx, eig_vec_mtx, ret)`**: Computes velocity operator matrix elements in the eigenbasis: `V = U* (dH/dk) U`, where U are eigenvectors.
+-   **`calc_left_pert_velo_mtx`, `calc_right_pert_velo_mtx`**: Calculate velocity matrices with first-order perturbative corrections due to exchange splitting.
+-   **`calc_exch_firstord`**: Calculates the first-order correction to the Hamiltonian due to changes in exchange field.
+-   **`calc_berry_z(self, z_comp, eig_val, x_mtx, y_mtx)`**: Calculates the z-component of Berry curvature for each band.
+-   **`calc_berry_diag`, `calc_berry_diag_sea`, `calc_berry_diag_surf`**: Calculate diagonal components of conductivity-like tensors (related to Berry curvature) using different formulations (e.g., Kubo-Streda, considering Fermi sea/surface terms).
+-   **`calc_fac_diag`, `calc_fac_sea`, `calc_fac_surf`**: Helper functions to calculate energy-dependent factors in Berry curvature expressions.
+-   **`drop_layer_derivative(self, k_idx)`**: Zeros out elements of `self%del_H` corresponding to specified layers.
+-   **`z_layer_states(self) result(z)`**: Returns the z-coordinates of atomic layers.
+-   **`free_ham(self)`**: Deallocates memory associated with the `hamil` object.
+-   **`test_herm(H, tag, verbose)`**: Tests if a matrix `H` is Hermitian.
+
+## Important Variables/Constants (within `type hamil`)
+
+-   **`E_fermi(:)`**: Array storing Fermi energy values. Crucial for determining occupations and transport properties.
+-   **`Vss_sig, Vpp_sig, Vpp_pi, V2pp_sig, V2pp_pi`**: Hopping parameters defining the band structure.
+-   **`t_so`**: Rashba spin-orbit coupling strength.
+-   **`eta_soc`**: Intrinsic p-orbital SOC strength.
+-   **`lambda`**: Local exchange field strength (for magnetism).
+-   **`lambda_KM`**: Kane-Mele SOC strength.
+-   **`t_2, phi_2`**: Haldane model parameters.
+-   **`gamma`**: Broadening parameter used in Green's functions and conductivity calculations.
+-   **`num_orb`**: Number of orbitals per atom site.
+-   **`num_up`**: Total number of spin-up basis states in the unit cell. The Hamiltonian matrix size is `(2 * num_up) x (2 * num_up)`.
+-   **`del_H(:,:)`**: The derivative of the Hamiltonian, dH/dk, used to calculate velocities.
+-   **`me, root`**: MPI rank and root process ID.
+-   Constants like `sigma_x`, `sigma_y`, `sigma_z` (Pauli matrices), `i_unit` (imaginary unit) are likely used from the `Constants` module.
+
+## Dependencies/Interactions
+
+-   **`m_config`**: Used for reading configuration parameters (`CFG_t`, `CFG_get`, `CFG_get_size`).
+-   **`output`**: Used for error messages and logging (`error_msg`).
+-   **`Class_unit_cell`**: Provides the `unit_cell` type (`UC`) which describes the crystal lattice, atomic positions, and connectivity (neighbors). This is fundamental for constructing the Hamiltonian.
+-   **`m_npy`**: Used for saving data in NumPy `.npy` format (e.g., `save_npy` for Fermi levels).
+-   **`mpi`**: Standard MPI module for parallel communication (`MPI_COMM_WORLD`, `MPI_Bcast`, `MPI_Comm_rank`, `MPI_Comm_size`, etc.).
+-   **`MYPI`**: Custom MPI utilities, possibly defining `MYPI_INT` or wrapper functions.
+-   **`Constants`**: Provides physical constants (e.g., `boltzmann_const`, `PI`, Pauli matrices `sigma_x, sigma_y, sigma_z`, imaginary unit `i_unit`, `c_0`, `c_1`, `c_i`) and possibly numerical precision parameters (`eta_sq`, `pos_eps`).
+-   **LAPACK/BLAS**: External libraries used for numerical linear algebra, specifically `zheevd` (or `zheev`) for diagonalizing Hermitian matrices to find eigenvalues and eigenvectors, and `zgemm` for matrix-matrix multiplication. These are implicitly used via Fortran's intrinsic interfaces or direct calls.
+
+The module interacts heavily with the `Class_unit_cell` to understand the geometry and connections between atoms, which dictates the non-zero elements of the Hamiltonian. It receives k-points as input and produces eigenvalues, eigenvectors, and velocity operators as output, which are then used by other parts of the larger program (e.g., `Class_k_space`) for calculating physical observables.

--- a/docs/k_space_F90.md
+++ b/docs/k_space_F90.md
@@ -1,0 +1,132 @@
+# Documentation for `src/k_space.F90`
+
+## Overview
+
+The `Class_k_space` module is responsible for calculations that involve sampling the Brillouin zone (k-space). This includes calculating band structures along specified paths, computing the Density of States (DOS), and evaluating Berry curvature related quantities like the Anomalous Hall Conductivity (AHC) and orbital magnetization. It handles the generation of k-point grids, manages MPI parallelization for k-point loops, and interfaces with the `Class_hamiltonian` module to obtain eigenvalues and velocity operators at each k-point. The module also implements adaptive k-mesh refinement strategies for accurate integration of Berry curvature.
+
+## Key Components
+
+### `module Class_k_space`
+
+This is the main module.
+
+### `type k_space`
+
+A derived data type that holds parameters and procedures related to k-space calculations.
+
+**Key Members (Parameters):**
+
+-   `new_k_pts (real(8), allocatable :: new_k_pts(:,:))`: Array storing newly generated k-points for a calculation step.
+-   `all_k_pts (real(8), allocatable :: all_k_pts(:,:))`: Array storing all k-points accumulated during adaptive refinement.
+-   `int_DOS (real(8), allocatable :: int_DOS(:))`: Integrated Density of States.
+-   `E_DOS (real(8), allocatable :: E_DOS(:))`: Energy grid for DOS calculation.
+-   `DOS_gamma (real(8))`: Broadening parameter ($\Gamma$) for DOS calculations.
+-   `DOS_lower, DOS_upper (real(8))`: Lower and upper energy bounds for DOS calculation.
+-   `temp (real(8))`: Temperature used in Fermi-Dirac distribution (primarily for Berry quantities).
+-   `DOS_num_k_pts (integer)`: Number of k-points per dimension for DOS calculations on a regular grid.
+-   `berry_num_k_pts (integer)`: Initial number of k-points per dimension for Berry curvature calculations.
+-   `ACA_num_k_pts (integer)`: Number of k-points for Anomalous Hall Conductivity (ACA) calculations (likely a specific type of Berry calculation).
+-   `num_DOS_pts (integer)`: Number of points on the energy grid for DOS.
+-   `num_k_pts (integer)`: Number of k-points per segment for band structure paths.
+-   `num_plot_pts (integer)`: Number of points per dimension for plotting Berry curvature.
+-   `nProcs (integer)`: Number of MPI processes.
+-   `me (integer)`: MPI rank of the current process.
+-   `berry_iter (integer)`: Maximum number of iterations for adaptive k-mesh refinement.
+-   `kpts_per_step (integer)`: Number of new k-points to add per refinement step per MPI process.
+-   `k_shift(3) (real(8))`: Shift applied to the k-space grid.
+-   `berry_conv_crit (real(8))`: Convergence criterion for Berry integration.
+-   `weights (real(8), allocatable :: weights(:))`: Integration weights for each k-point (e.g., Voronoi cell area / number of triangle vertices).
+-   `elem_nodes (integer, allocatable :: elem_nodes(:,:))`: Connectivity list for k-point triangulation (defines triangles).
+-   `refine_weights(:), refine_weights_surf(:), refine_weights_sea(:) (real(8), allocatable)`: Weights used to guide adaptive mesh refinement, based on Berry curvature contributions.
+-   `k1_param(:), k2_param(:) (real(8), allocatable)`: Parameters defining k-paths or grids (e.g., start/end points, number of points).
+-   `filling (character(len=300))`: String indicating how k-points are generated (e.g., "path_rel", "path_abs", "grid").
+-   `prefix (character(len=300))`: Output file prefix.
+-   `chosen_weights (character(len=300))`: Which quantity to use for adaptive refinement weights ("hall" or "orbmag").
+-   `ada_mode (character(len=6))`: Mode for adaptive refinement ("area", "weight", "mixed").
+-   `berry_component (character(len=6))`: Specifies which component of Berry curvature or related tensor to calculate (e.g., "xy", "xx", "xysurf").
+-   `perform_pad (logical)`: Whether to pad the k-point list to ensure an even distribution across MPI processes.
+-   `calc_hall, calc_hall_diag, calc_orbmag (logical)`: Flags to enable calculation of Hall conductivity (standard Kubo), diagonal Hall conductivity (Kubo-Streda like), and orbital magnetization.
+-   `test_run (logical)`: Flag to perform unit tests.
+-   `berry_safe (logical)`: Flag to save intermediate Berry curvature data.
+-   `ham (type(hamil))`: The Hamiltonian object.
+-   `units (type(units))`: Units object.
+
+**Key Procedures (Methods):**
+
+-   **`init_k_space(cfg) result(self)`**: Constructor. Initializes `k_space` object from configuration `cfg`. Sets up parameters and broadcasts them.
+-   **`Bcast_k_space(self)`**: Broadcasts `k_space` parameters to all MPI ranks.
+-   **`calc_and_print_band(self)`**: Calculates and saves band structure.
+    -   Calls `setup_k_path_rel`, `setup_k_path_abs`, or `setup_k_grid` based on `self%filling`.
+    -   Distributes k-points among MPI processes.
+    -   Calls `self%ham%calc_eigenvalues`.
+    -   Gathers and saves k-points and eigenvalues.
+-   **`calc_and_print_dos(self)`**: Calculates and saves DOS and projected DOS (PDOS).
+    -   Sets up a k-grid using `setup_inte_grid_para` or `setup_inte_grid_hex`.
+    -   Calls `calc_pdos`.
+    -   Saves DOS, PDOS, and integrated DOS.
+-   **`calc_pdos(self, E, PDOS)`**: Calculates projected density of states.
+    -   Loops over k-points, calculates eigenvalues and eigenvectors using `zheevd`.
+    -   Projects eigenvectors onto atomic orbitals and broadens with `lorentzian`.
+-   **`calc_berry_quantities(self, pert_log)`**: Main routine for calculating Berry curvature related quantities (AHC, orbital magnetization).
+    -   Calls `setup_berry_inte_grid` for initial k-mesh.
+    -   Iteratively refines the k-mesh:
+        -   `calc_new_berry_points`: Calculates eigenvalues, Berry curvature ($\Omega_z$), and orbital magnetization moments ($Q_L, Q_{IC}$) at new k-points using `self%ham%calc_eig_and_velo`.
+        -   `append_kpts`, `append_eigval`, `append_quantity`: Adds new data to global lists.
+        -   `integrate_hall`, `integrate_hall_surf`, `integrate_hall_sea`, `integrate_orbmag`: Performs integration over the current k-mesh using `set_weights_ksp` (based on triangulation via `run_triang`).
+        -   `process_hall`, `process_hall_surf`, `process_orbmag`: Checks convergence and saves iteration data.
+        -   `set_hall_weights`, `set_orbmag_weights`: Determines weights for next refinement step.
+        -   `add_kpts_iter`: Selects new k-points based on `ada_mode` and weights.
+    -   Calls `finalize_hall`, `finalize_hall_surf`, `finalize_orbmag` to save final results.
+-   **`setup_k_path_rel(self)` / `setup_k_path_abs(self)`**: Generates k-points along a path defined by relative (to reciprocal lattice vectors) or absolute coordinates.
+-   **`setup_k_grid(self)`**: Generates a regular 2D grid of k-points.
+-   **`setup_inte_grid_para(self, n_k, padding)`**: Sets up a parallelogram-shaped k-grid based on reciprocal lattice vectors.
+-   **`setup_inte_grid_hex(self, n_k)`**: Sets up a k-grid suitable for hexagonal Brillouin zones.
+-   **`setup_berry_inte_grid(self)`**: Calls appropriate grid setup for Berry calculations.
+-   **`integrate_hall(self, kidx_all, omega_z_all, eig_val_all, hall)`**: Integrates $\Omega_z \cdot f(E)$ to get Hall conductivity.
+-   **`integrate_hall_surf(self, kidx_all, omega_z_all, hall)` / `integrate_hall_sea(...)`**: Integrates components for diagonal conductivity (Fermi surface and Fermi sea terms).
+-   **`integrate_orbmag(self, Q_kidx_all, Q_L_all, Q_IC_all, orb_mag, orbmag_L, orbmag_IC)`**: Integrates local ($Q_L$) and itinerant circulation ($Q_{IC}$) moments to get orbital magnetization.
+-   **`set_weights_ksp(self)`**: Calculates integration weights for k-points based on the area of surrounding triangles from `run_triang`.
+-   **`lorentzian(self, x) result(lor)`**: Calculates Lorentzian broadening function.
+-   **`find_fermi(self, cfg)`**: Determines Fermi energy based on target filling from integrated DOS.
+-   **`calc_ACA(self)`**: Calculates Anomalous Hall Conductivity using a specific formulation (likely related to orbital moments of p-orbitals). Calls `calc_ACA_singleK`.
+-   **`plot_omega_square(self)`**: Generates data for plotting Berry curvature over a 2D k-grid.
+-   **`free_ksp(self)`**: Deallocates memory.
+
+## Important Variables/Constants
+
+-   **`DOS_gamma (real(8))`**: Lorentzian broadening width for DOS calculations.
+-   **`berry_num_k_pts (integer)`**: The initial density of the k-mesh for Berry calculations. The mesh is adaptively refined from this starting point.
+-   **`k_shift(3) (real(8))`**: A vector used to shift the entire k-mesh. Useful for sampling around specific points or avoiding high-symmetry points if necessary.
+-   **`filling (character(len=300))`**: Controls how k-points are generated for band structure (path, grid).
+-   **`prefix (character(len=300))`**: Used for naming output files.
+-   **`elem_nodes (integer, allocatable :: elem_nodes(:,:))`**: Stores the triangulation of the k-mesh, crucial for integration.
+-   **`weights (real(8), allocatable :: weights(:))`**: Stores the integration weight for each k-point.
+-   **`ada_mode (character(len=6))`**: Determines the strategy for adaptive k-mesh refinement (e.g., 'area' focuses on largest triangles, 'weight' focuses on largest Berry curvature contributions).
+-   `PI`, `deg_30`, `deg_60`, `speed_of_light`, `eta`, `pos_eps` (likely from `Constants` or `Class_helper`): Mathematical and physical constants.
+
+## Dependencies/Interactions
+
+-   **`m_config`**: For reading configuration parameters (`CFG_t`, `CFG_get`, `create_dir`).
+-   **`m_npy`**: For saving data in NumPy `.npy` format (`save_npy`).
+-   **`mpi`**: Standard MPI module for parallelization (`MPI_COMM_WORLD`, `MPI_Bcast`, `MPI_Reduce`, `MPI_Gatherv`, etc.).
+-   **`Class_hamiltonian`**: Crucial dependency. The `k_space` type contains a `hamil` object (`self%ham`). This is used to:
+    -   Get Hamiltonian parameters.
+    -   Calculate eigenvalues (`self%ham%calc_eigenvalues`, `self%ham%calc_eig_and_velo`).
+    -   Calculate velocity operators (dH/dk via `self%ham%calc_eig_and_velo`, which calls `self%ham%set_derivative_k` and `self%ham%calc_velo_mtx`).
+    -   Calculate Berry curvature components (`self%ham%calc_berry_z`, `self%ham%calc_berry_diag_surf`, `self%ham%calc_berry_diag_sea`).
+    -   Get Fermi-Dirac distribution (`self%ham%fermi_distr`).
+    -   Get unit cell information (`self%ham%UC%...`).
+-   **`Class_helper`**: Provides various helper functions:
+    -   `my_section`, `sections`: For distributing loop iterations among MPI processes.
+    -   `linspace`: For generating evenly spaced points.
+    -   `cross_prod`, `my_norm2`: Vector operations.
+    -   `qargsort`: For sorting and getting indices.
+    -   `find_list_idx`: To find an element in a list.
+    -   `append_kidx`, `append_eigval`, `append_quantity`: Utilities for concatenating arrays during adaptive refinement.
+    -   Possibly constants like `deg_30`, `deg_60`, `PI`, `eta`, `pos_eps`.
+-   **`MYPI`**: Custom MPI utilities, possibly for error checking (`check_ierr`) or custom types (`MYPI_INT`).
+-   **`ieee_arithmetic`**: For checking for NaN values (`ieee_is_nan`).
+-   **`run_triang` (interface)**: External library/subroutine for Delaunay triangulation of the k-points to define `elem_nodes`. This is fundamental for the integration scheme.
+-   **LAPACK**: Implicitly used via `zheevd` (called within `calc_pdos` and `self%ham%calc_eig_and_velo`, etc.) for eigenvalue/eigenvector computations.
+
+The module orchestrates complex calculations by combining k-space sampling strategies with Hamiltonian evaluations and subsequent post-processing (integration, summation) to derive physical quantities.

--- a/docs/main_f90.md
+++ b/docs/main_f90.md
@@ -1,0 +1,95 @@
+# Documentation for `src/main.f90`
+
+## Overview
+
+This program, named `STB`, is the main driver for a solid-state physics calculation package. It initializes MPI for parallel processing, reads input configuration files, and then processes each file to perform various calculations like band structure, density of states (DOS), Berry curvature related quantities (e.g., Hall conductivity, orbital magnetization), and Anomalous Hall Conductivity (ACA). The program is designed to handle multiple input files and distribute calculations across MPI ranks.
+
+## Key Components
+
+### `program STB`
+
+The main program unit.
+- Initializes and finalizes MPI.
+- Seeds the random number generator.
+- Calls `get_inp_files` to determine the input configuration files to be processed.
+- Broadcasts the number of files to all MPI ranks.
+- Loops through each input file and calls `process_file` to handle the calculations for that specific configuration.
+
+### `subroutine process_file(inp_file)`
+
+This subroutine orchestrates the calculations for a single input configuration file.
+- **Arguments:**
+    - `inp_file (character(len=300), intent(in))`: The path to the input configuration file.
+- Reads the configuration file using `CFG_read_file` (only on the root MPI rank).
+- Calls `add_full_cfg` to populate the configuration with default or derived values.
+- Retrieves various calculation flags (e.g., `perform_band`, `perform_dos`, `calc_hall`) from the configuration.
+- Broadcasts these flags and other essential parameters (like `fermi_type`, `pert_log`) to all MPI ranks.
+- Initializes the k-space representation (`Ksp`) using `init_k_space` based on the configuration.
+- Saves the complete configuration to a file (e.g., `setup.cfg`) using `save_cfg` (only on the root MPI rank).
+- Performs calculations based on the enabled flags:
+    - Band structure (`Ksp%calc_and_print_band()`).
+    - Sets Fermi energy if `fermi_type` is "fixed".
+    - Density of States (`Ksp%calc_and_print_dos()`).
+    - Finds Fermi energy based on filling if `fermi_type` is "filling" and DOS was calculated.
+    - Berry quantities (Hall conductivity, orbital magnetization) (`Ksp%calc_berry_quantities(pert_log)`).
+    - Anomalous Hall Conductivity (`Ksp%calc_ACA()`).
+    - Plots Berry curvature (`Ksp%plot_omega_square()`) if `plot_omega` is true.
+- Measures and prints execution time for initialization and total processing.
+- Frees allocated memory associated with `Ksp` using `Ksp%free_ksp()`.
+- Clears the configuration object `cfg` (only on the root MPI rank).
+
+### `subroutine get_inp_files(n_files, inp_files)`
+
+Determines the list of input configuration files to be processed based on command-line arguments.
+- **Output Arguments:**
+    - `n_files (integer, intent(out))`: The total number of input files.
+    - `inp_files (character(len=300), allocatable, intent(out))`: An array of strings, where each string is the path to an input file.
+- Logic for handling command-line arguments (only on the root MPI rank):
+    - If 0 arguments: Prints an error and aborts.
+    - If 1 argument: Assumes it's a single input file.
+    - If 2 arguments: Assumes the first is a base string and the second is the number of files (`N`). Generates filenames like `base_str0.cfg`, `base_str1.cfg`, ..., `base_str(N-1).cfg`.
+    - If 3 arguments: Assumes the first is a base string, the second is a start index, and the third is an end index. Generates filenames accordingly.
+- Broadcasts `n_files` to all MPI ranks.
+- Allocates `inp_files` on non-root ranks.
+- Broadcasts each input filename to all MPI ranks.
+
+### `subroutine add_full_cfg(cfg)`
+
+Populates the configuration object (`cfg`) with a comprehensive set of default parameters and their descriptions for various aspects of the calculation (units, Hamiltonian parameters, grid details, band structure, DOS, Berry calculations, output settings, ACA, layer dropout, and plotting).
+- **Arguments:**
+    - `cfg (type(CFG_t))`: The configuration object to be populated.
+- Uses `CFG_add` to define numerous configuration parameters with their default values and descriptions. This acts as a schema for the expected configuration options.
+
+### `subroutine save_cfg(cfg)`
+
+Saves the current configuration to a file.
+- **Arguments:**
+    - `cfg (type(CFG_t))`: The configuration object to be saved.
+- Adds a timestamp for when the calculation started (`calculation%start_time`) to the configuration.
+- Retrieves the output prefix (`output%band_prefix`) from the configuration.
+- Writes the configuration to a file named `[prefix]setup.cfg` using `CFG_write`.
+
+## Important Variables/Constants
+
+- **`me (integer)`**: The MPI rank of the current process.
+- **`root (integer, parameter, implicit in mpi module)`**: Typically rank 0, used for tasks like I/O and broadcasting initial data. The actual value is likely defined in the `mpi` module (e.g., `parameter :: root = 0`).
+- **`Ksp (type(k_space))`**: An instance of the `k_space` class, which likely encapsulates the k-space grid, Hamiltonian, and methods for performing various calculations.
+- **`cfg (type(CFG_t))`**: A derived type variable holding the configuration parameters for the current calculation.
+- **`inp_files (character(len=300), allocatable :: inp_files(:))`**: Array storing the names of input configuration files.
+- **`n_files (integer)`**: The number of input files to process.
+- **`time_fmt (character(len=*), parameter)`**: Format string for timing output.
+
+## Dependencies/Interactions
+
+The `STB` program and its subroutines utilize several modules:
+
+- **`Class_k_space`**: Provides the `k_space` derived type (`Ksp`) and associated methods for calculations (band structure, DOS, Berry quantities, ACA).
+- **`m_config`**: Provides the `CFG_t` type and subroutines for managing configuration files (`CFG_read_file`, `CFG_get`, `CFG_add`, `CFG_write`, `CFG_clear`).
+- **`m_npy`**: Likely used for reading/writing data in the NumPy .npy format, possibly for compatibility with Python-based tools or for efficient data storage. (Though not explicitly used in `main.f90` directly, it might be a dependency of `Class_k_space` or other modules).
+- **`output`**: Potentially contains subroutines for formatted output or logging (e.g., `error_msg`).
+- **`mpi`**: Provides MPI constants (e.g., `MPI_COMM_WORLD`, `MYPI_INT`, `MPI_LOGICAL`, `MPI_CHARACTER`) and procedures (`MPI_Init`, `MPI_Comm_rank`, `MPI_Bcast`, `MPI_Finalize`, `MPI_Wtime`). The constant `root` is also likely defined here.
+- **`Constants`**: Might define physical constants or other shared parameters.
+- **`Class_unit_cell`**: Likely provides the definition for the unit cell structure, which would be a component of the Hamiltonian within `Class_k_space`. (e.g. `Ksp%ham%UC%num_atoms`)
+- **`mypi`**: Possibly a custom MPI utility module, or it could be defining `MYPI_INT` if it's not a standard MPI constant.
+
+The program interacts with the file system by reading input configuration files and writing output files (e.g., band structure data, DOS data, and the `setup.cfg` file). It also interacts with the command line to receive input file names or patterns.

--- a/docs/unit_cell_f90.md
+++ b/docs/unit_cell_f90.md
@@ -1,0 +1,112 @@
+# Documentation for `src/unit_cell.f90`
+
+## Overview
+
+The `Class_unit_cell` module defines the structure and magnetic configuration of the unit cell in a crystalline material. It handles the geometry of the lattice, including lattice vectors and reciprocal lattice vectors, the positions and types of atoms within the unit cell, and the connectivity between these atoms (nearest neighbors, second nearest neighbors). A significant part of this module is dedicated to setting up various magnetic textures, such as ferromagnetic, antiferromagnetic, spiral, and skyrmion configurations.
+
+## Key Components
+
+### `module Class_unit_cell`
+
+This is the main module.
+
+### `enum, bind(c)` for Connection Types
+
+Defines enumerators for different types of neighbor connections:
+-   `nn_conn`: Nearest Neighbor connection.
+-   `snd_nn_conn`: Second Nearest Neighbor connection.
+-   `oop_conn`: Out-of-plane connection (though primarily 2D systems seem to be handled).
+
+### `type unit_cell`
+
+A derived data type that encapsulates all information about the unit cell.
+
+**Key Members (Parameters):**
+
+-   `lattice(2, 2) (real(8))`: Real-space lattice vectors (2 vectors in 2D).
+-   `rez_lattice(2, 2) (real(8))`: Reciprocal lattice vectors.
+-   `num_atoms (integer)`: Number of non-redundant atoms in the unit cell.
+-   `atom_per_dim (integer)`: Number of atoms along a characteristic dimension (e.g., radius for hexagonal cells, side length for square cells).
+-   `nProcs, me (integer)`: MPI process count and rank.
+-   `n_wind (integer)`: Winding number for certain magnetic textures (e.g., skyrmions, linear rotation spirals).
+-   `wavevector (integer, allocatable :: wavevector(:))`: Wavevector `q` for spiral magnetic orders, typically in units of reciprocal lattice vectors.
+-   `lattice_constant (real(8))`: The fundamental lattice spacing.
+-   `eps (real(8))`: Tolerance for positional accuracy when identifying atoms or neighbors.
+-   `ferro_phi, ferro_theta (real(8))`: Spherical angles ($\phi, \theta$) for uniform ferromagnetic alignment.
+-   `cone_angle (real(8))`: Cone angle for conical spiral magnetic structures.
+-   `anticol_phi(:), anticol_theta(:) (real(8), allocatable)`: Arrays of angles for defining antiferromagnetic or more complex collinear/non-collinear structures, often used for defining base states for perturbations or spirals.
+-   `axis_phi, axis_theta (real(8))`: Spherical angles defining the rotation axis for spiral magnetism.
+-   `atan_factor, atan_pref, skyrm_middle, dblatan_dist, dblatan_pref (real(8))`: Parameters for defining skyrmion profiles using `atan` or double `atan` functions for the magnetization tilt.
+-   `atoms (type(atom), dimension(:), allocatable)`: Array of `atom` objects that constitute the unit cell. Each `atom` object (from `Class_atom`) stores its position, magnetic moment, site type, and neighbor information.
+-   `units (type(units))`: Object storing physical units.
+-   `uc_type (character(len=25))`: String identifier for the unit cell type (e.g., "square_2d", "honey_2d", "honey_line", "file_square").
+-   `mag_type (character(len=25))`: String identifier for the type of magnetic ordering.
+-   `spiral_type (character(len=25))`: Specific type of spiral (e.g., "anticol", "cone").
+-   `mag_file (character(len=300))`: Path to a file defining a custom magnetic configuration.
+-   `molecule (logical)`: If true, treats the system as an isolated molecule (likely affects boundary conditions or k-space interpretation).
+-   `test_run (logical)`: Flag to run internal consistency tests.
+-   `pert_log (logical)`: Flag indicating if Berry curvature calculations should use first-order perturbation theory (related to magnetic perturbations).
+
+**Key Procedures (Methods):**
+
+-   **`init_unit(cfg) result(self)`**: Constructor. Initializes the `unit_cell` object from a configuration `cfg`.
+    -   Reads general parameters (epsilon, magnetic types, lattice constant, etc.).
+    -   Broadcasts parameters using `Bcast_UC`.
+    -   Calls a specific `init_unit_TYPE` subroutine based on `uc_type`.
+    -   Calculates reciprocal lattice vectors.
+-   **`Bcast_UC(self)`**: Broadcasts unit cell parameters to all MPI ranks.
+-   **`init_unit_square(self)`**: Initializes a square 2D unit cell. Calls `setup_square` and then `setup_gen_conn`. Sets magnetic order based on `mag_type`.
+-   **`init_unit_honey_hexa(self)`**: Initializes a hexagonal unit cell with honeycomb lattice structure. Uses `make_hexagon` and `setup_honey`, then `setup_gen_conn` and `set_honey_snd_nearest`. Sets magnetic order.
+-   **`init_unit_honey_line(self)`**: Initializes a line-shaped (ribbon-like) unit cell with honeycomb structure. Uses `make_honeycomb_line`, `setup_honey`, `setup_gen_conn`, and `set_honey_snd_nearest_line`. Sets magnetic order.
+-   **`init_file_square(self)`**: Initializes a unit cell from a file, typically defining atomic positions and magnetic moments.
+-   **`setup_square(self)`**: Populates atomic positions for a square lattice.
+-   **`setup_honey(self, hexagon, site_type)`**: Populates atomic positions for a honeycomb lattice based on pre-calculated `hexagon` coordinates and `site_type` (A or B).
+-   **`make_hexagon(self, hexagon, site_type)`**: Generates the atomic coordinates and site types for a hexagonal supercell of a honeycomb lattice.
+-   **`make_honeycomb_line(self, line, site_type)`**: Generates atomic coordinates and site types for a honeycomb ribbon.
+-   **`setup_gen_conn(self, conn_mtx, conn_type, transl_mtx)`**: General routine to find and store neighbor information for each atom.
+    -   `conn_mtx`: Defines relative vectors to potential neighbors.
+    -   `conn_type`: Specifies the type of connection (nn_conn, snd_nn_conn).
+    -   `transl_mtx`: Defines translation vectors to adjacent unit cells for periodic boundary conditions.
+    -   Calls `gen_find_neigh` for each potential connection.
+-   **`gen_find_neigh(self, start, conn, transl_mtx) result(neigh)`**: Finds the index of a neighboring atom given a starting atom, a connection vector, and periodic translation vectors. Uses `in_cell`.
+-   **`in_cell(self, start, conn) result(idx)`**: Checks if the atom at `start + conn` is within the current list of atoms and returns its index.
+-   **`set_honey_snd_nearest(self)` / `set_honey_snd_nearest_line(self)`**: Specifically sets up second-nearest neighbor connections for honeycomb structures.
+-   **Magnetic Configuration Methods:**
+    -   `set_mag_ferro(self)`: Sets all atomic magnetic moments to a uniform ferromagnetic state.
+    -   `set_mag_anticol(self)`: Sets moments based on `self%anticol_phi` and `self%anticol_theta`, allowing for various collinear/non-collinear antiferromagnetic or complex states. Can also set a base collinear state if `pert_log` is true.
+    -   `set_mag_random(self)`: Sets random magnetic moments.
+    -   `set_mag_x_spiral_square(self)`: Sets a 1D spiral along x for a square lattice.
+    -   `set_mag_linrot_1D_spiral(self, center, UC_l)`: Sets a 1D linear spiral/spin-wave. `m0_A` and `m0_B` define the base magnetic state(s) being rotated. The rotation angle depends on the projection of the atom's position onto the `wavevector`.
+    -   `set_mag_linrot_1D_spiral_honey(self)`: Wrapper for 1D spiral on honeycomb, choosing between `anticol` or `cone` base states for the spiral.
+    -   `set_mag_linrot_1D_spiral_m0_anticol(self)` / `set_mag_linrot_1D_spiral_m0_cone(self)`: Initialize `m0_A` and `m0_B` (base moments for the spiral) for anticollinear or conical configurations respectively.
+    -   `set_mag_linrot_skyrm(self, center, radius)`: Sets a skyrmion magnetic texture where moments rotate based on their position relative to `center` and `radius`.
+    -   `set_mag_atan_skyrm(self, center, radius)` / `set_mag_dblatan_skyrm(self, center, radius)`: Skyrmion profiles defined by `atan` or double `atan` functions for smoother or more controlled domain walls.
+    -   `set_mag_linrot_skrym_square(self)` / `set_mag_linrot_skrym_honey(self)`: Wrappers for skyrmions on square or honeycomb lattices.
+-   `save_unit_cell(self, folder)`: Saves unit cell information (positions, magnetic moments, lattice vectors, neighbor lists) to files using `m_npy`.
+-   `calc_area(self) result(area)`: Calculates the 2D area of the unit cell.
+-   `free_uc(self)`: Deallocates memory associated with the unit cell, including its atoms.
+-   `run_tests(self)`: Performs internal consistency checks, e.g., for MPI broadcasted values.
+
+## Important Variables/Constants (within `type unit_cell`)
+
+-   **`lattice(2,2)`**: The two 2D real-space lattice vectors defining the unit cell.
+-   **`rez_lattice(2,2)`**: The two 2D reciprocal lattice vectors.
+-   **`num_atoms`**: Total number of atoms in the defined unit cell.
+-   **`uc_type (character)`**: String specifying the lattice type (e.g., "square_2d", "honey_2d"). This determines which initialization routines are called.
+-   **`mag_type (character)`**: String specifying the magnetic configuration (e.g., "ferro", "1Dspiral", "lin_skyrm"). This determines which `set_mag_TYPE` routine is called.
+-   **`atoms(:) (type(atom))`**: The array holding all atomic information. The properties of these `atom` objects (position, magnetic moment) are set by the methods in `Class_unit_cell`.
+-   `nn_conn`, `snd_nn_conn`: Enum values used to tag connection types.
+
+## Dependencies/Interactions
+
+-   **`Class_atom`**: Fundamental. The `unit_cell` type contains an array of `atom` objects. Methods in `Class_unit_cell` call methods of the `atom` type (e.g., `init_ferro_z`, `set_sphere`, `set_m_cart`, `free_atm`).
+-   **`Class_helper`**: Provides utility functions like `my_norm2` (vector norm), `cross_prod`, `R_mtx` (rotation matrix generation), `n_times_phi` (for multi-q spirals/skyrmions), `deg_30`, `deg_60`, `PI`, `pos_eps`.
+-   **`m_config`**: Used to read configuration parameters from a file (`CFG_t`, `CFG_get`, `CFG_get_size`).
+-   **`output`**: For error messages (`error_msg`).
+-   **`m_npy`**: Used for saving unit cell data to `.npy` files (`save_npy`).
+-   **`mpi`**: Standard MPI module for parallel communication.
+-   **`mypi`**: Custom MPI utilities, possibly for `MYPI_INT` or error checking (`check_ierr`).
+-   **`Constants`**: Provides physical constants and mathematical constants (e.g., `PI`, `A_site`, `B_site` enumerators if site types are defined there).
+-   **`class_Units`**: Provides the `units` type for managing physical units of quantities like length and energy.
+
+This module acts as the primary store and manager of the crystal and magnetic structure, providing this information to other modules like `Class_hamiltonian` which then build the electronic model.


### PR DESCRIPTION
Add initial Markdown documentation for core source files.

This commit introduces Markdown documentation for the following core Fortran files:
- src/main.f90
- src/hamiltonian.f90
- src/k_space.F90
- src/unit_cell.f90
- src/atom.f90

Each Markdown file, located in the `docs/` directory, provides:
- An overview of the file's purpose.
- A list of key components (modules, types, important subroutines/functions).
- Descriptions of important variables or constants.
- Notes on dependencies and interactions with other parts of the system.

This documentation aims to help you understand and maintain the codebase.